### PR TITLE
EndPlay is now triggered on child classes

### DIFF
--- a/Source/TcpSocketPlugin/Private/TcpSocketConnection.cpp
+++ b/Source/TcpSocketPlugin/Private/TcpSocketConnection.cpp
@@ -27,6 +27,7 @@ void ATcpSocketConnection::BeginPlay()
 
 void ATcpSocketConnection::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
+	Super::EndPlay(EndPlayReason);
 	TArray<int32> keys;
 	TcpWorkers.GetKeys(keys);
 


### PR DESCRIPTION
Not calling the super's EndPlay made it that the event wasn't trigger on child classes.