### PR TITLE
Add Message_ReadFullString function

### DIFF
--- a/Source/TcpSocketPlugin/Public/TcpSocketConnection.h
+++ b/Source/TcpSocketPlugin/Public/TcpSocketConnection.h
@@ -121,6 +121,9 @@ public:
 	UFUNCTION(BlueprintCallable, meta = (DisplayName = "Read String", Keywords = "read string"), Category = "Socket")
 	static FString Message_ReadString(UPARAM(ref) TArray<uint8>& Message, int32 StringLength);
 
+	UFUNCTION(BlueprintCallable, meta = (DisplayName = "Read Full String", Keywords = "read string"), Category = "Socket")
+	static FString Message_ReadFullString(UPARAM(ref) TArray<uint8>& Message);
+
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Socket")
 	bool isConnected(int32 ConnectionId);
 
@@ -203,6 +206,8 @@ public:
 private:
 	/* Blocking send */
 	bool BlockingSend(const uint8* Data, int32 BytesToSend);
+
+	bool IsReceivedData(const TArray<uint8>& receivedData);
 
 	/** thread should continue running */
 	FThreadSafeBool bRun = false;


### PR DESCRIPTION
In situations where I need to receive a string, I first need to obtain the byte length and then use the Message_ReadString function to convert it. Therefore, I’d like to add a Message_ReadFullString function that can directly convert the entire message based on its length.

![1](https://github.com/user-attachments/assets/84153e31-832c-4be8-bf50-107348b547d0)
![2](https://github.com/user-attachments/assets/c1b4e157-4392-4789-b730-1cbd4e685f01)
